### PR TITLE
remove local server method from getting started page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,63 +1,38 @@
 # Getting Started
 
-Welcome to the ml5.js documentation. Here you'll find everything you need to get up and started with ml5.js.
+This tutorial uses ml5.js to:
+1. Load a pre-trained ml5.js image classification model
+2. Load an image for the model to identify the object in the image
+3. Get the results from the model and display them on the canvas
 
-## Create an Empty Project
+This tutorial is a p5.js sketch running on [p5.js web editor](https://editor.p5js.org/). To follow this tutorial, create an empty project on the p5.js web editor as instructed below.
+1. Open the p5.js web editor.
+2. Sign up or log in to your account. This is required because you will need to upload files to the project directory later on in the tutorial.
 
-First, we need to create an empty project to start with. Here, we introduces two ways to initialize your project:
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> You can find the full code for this tutorial at [imageClassifier single image example code](https://editor.p5js.org/ml5/sketches/pjPr6XmPY). Press the run button to see the code in action._
 
-### Try ml5.js Online
+## Set up ml5.js {docsify-ignore}
 
-If you would like to get a taste of ml5.js in minutes, the easiest way is using the [p5.js editor](https://editor.p5js.org/). You can open the web editor and follow [the next step to import the ml5 library](/?id=try-ml5js-online-1).
+Unfold the project directory by clicking the arrow `>` at the top left corner of the p5.js editor.
 
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with p5.js, check out the [p5.js Get Started page](https://p5js.org/get-started/) to know more!_
-
-### Try ml5.js Locally
-
-If you want to start a project from scratch and develop it locally, make sure to have these tools ready:
-
-> - <img class="inline-img" src="assets/gettingstarted-memo.png" alt="text editor icon" aria-hidden="true"> A text editor (e.g. [WebStorm](https://www.jetbrains.com/webstorm/), [Visual Studio Code](https://code.visualstudio.com/), [Sublime Text](https://www.sublimetext.com/))
-> - <img class="inline-img" src="assets/gettingstarted-computer.png" alt="browser icon" aria-hidden="true"> Your web browser: Chrome & Firefox preferred
-
-Your project directory should look something like this:
-
-```
-|_ /my-first-ml5-project
-  |_ index.html
-  |_ sketch.js
-```
-
-**Where**:
-
-- <img class="inline-img" src="assets/gettingstarted-open-file-folder.png" alt="folder icon" aria-hidden="true">**my-first-ml5-project/**: is the root project folder
-  - &ensp; <img class="inline-img" src="assets/gettingstarted-spiral-note-pad.png" alt="file icon" aria-hidden="true">**index.html**: is an .html file that has your html markup and library references
-  - &ensp; <img class="inline-img" src="assets/gettingstarted-spiral-note-pad.png" alt="file icon" aria-hidden="true">**sketch.js**: is where you'll be writing your javascript
-
-If you are done, follow [the next step to import the ml5 library](/?id=try-ml5js-locally-1).
-
-## Import ml5.js Library
-
-### Try ml5.js Online
-
-Open the sidebar revealing the **Sketch Files** by clicking the arrow **'>'** at the top left corner of the p5.js editor.
-
+<!-- TODO: photoshop image so that all have 800 px width before styling -->
 <center>
-    <img alt="screenshot of sketch files on the p5 web editor interface" src="assets/gettingstarted-sketch-folder.png">
+    <img alt="screenshot of sketch files on the p5 web editor interface" width="300" src="assets/gettingstarted-sketch-folder.png">
 </center>
 
-In the **index.html** file, copy and paste the following CDN link inside the **&lt;head&gt;** tag.
+In the `index.html` file, copy and paste the following CDN link inside the `<head>` tag.
 
 ```html
 <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js"></script>
 ```
 
 <center>
-    <img alt="screenshot of importing ml5 library in index.html file" src="assets/gettingstarted-import-lib.png">
+    <img alt="screenshot of importing ml5 library in index.html file" width="600" src="assets/gettingstarted-import-lib.png">
 </center>
 
-To check if the ml5.js library has been imported successfully, switch back to **sketch.js**.
+To check if the ml5.js library has been imported successfully, switch back to `sketch.js`.
 
-Include this line of code: `console.log('ml5 version:', ml5.version);` inside the **setup()** function.
+Include this line of code: `console.log('ml5 version:', ml5.version);` inside the `setup()` function.
 
 ```js
 function setup() {
@@ -73,122 +48,117 @@ function draw() {
 If everything loaded properly you should see the version number of the ml5 library show up in the console.
 
 <center>
-    <img  alt="screenshot of printing ml5 version in the console" src="assets/gettingstarted-ml5-version.png">
+    <img  alt="screenshot of printing ml5 version in the console" width="300" src="assets/gettingstarted-ml5-version.png">
 </center>
 
-Follow [the next step to prepare your image assets](/?id=try-ml5js-online-2)!
+## Load pretrained ml5.js model {docsify-ignore}
 
-### Try ml5.js Locally
+In the `sketch.js` file, define a variable called `classifier` to hold the image classifier model.
 
-Open your **index.html** file.
-
-Here you can see that we reference the needed JavaScript libraries, so that they get loaded by the browser as the page loads. This includes our ml5.js version as well as p5.js. You can copy and paste this into your **index.html** file or for good practice you can type it all out. Make sure to save the file and refresh your browser after saving.
-
-```html
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Image classification using MobileNet and p5.js</title>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.0.0/p5.min.js"></script>
-    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js"></script>
-  </head>
-
-  <body>
-    <h1>Image classification using MobileNet and p5.js</h1>
-    <script src="sketch.js"></script>
-  </body>
-</html>
+```js
+let classifier;
 ```
 
-Follow [the next step to prepare your image assets](/?id=try-ml5js-locally-2)!
+Add a `preload()` function to load the image classification model. In this example, we are using the MobileNet model.
 
-## Prepare Image Assets For Your First Sketch {docsify-ignore}
+```js
+function preload() {
+  classifier = ml5.imageClassifier("MobileNet");
+}
+```
 
-If you've arrived here, we assume you've imported ml5.js library to your project. Now, let's prepare the image assets we will be using soon.
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with terms like `pretrained model`, `classification`, `classifier`, `preload function`, `MobileNet` and would like to learn more about them, check out our [ml5 Glossary](/learning/ml5-glossary) for a quick intro._
 
-### Try ml5.js Online
 
-Open the sidebar revealing the **Sketch Files** by clicking the arrow **'>'** at the top left corner of the p5.js editor.
+## Load an image for the model to identify {docsify-ignore}
+
+Unfold the project directory by clicking the arrow `>` at the top left corner of the p5.js editor.
 
 <center>
-    <img alt="screenshot of sketch files on the p5 web editor interface" src="assets/gettingstarted-sketch-folder.png">
+    <img alt="screenshot of sketch files on the p5 web editor interface" width="300" src="assets/gettingstarted-sketch-folder.png">
 </center>
 
 Create a new folder called `images`.
 
 <center>
-    <img alt="screenshot of creating images folder" src="assets/gettingstarted-create_folder.png">
+    <img alt="screenshot of creating images folder" width="300" src="assets/gettingstarted-create_folder.png">
 </center>
 
 And upload a bird image named `bird.png` to the `images` folder. Remember to login to see this option.
 
 <center>
-    <img alt="screenshot of uploading file to p5 web editor" src="assets/gettingstarted-upload-file.png">
+    <img alt="screenshot of uploading file to p5 web editor" width="300" src="assets/gettingstarted-upload-file.png">
 </center>
 
-Now, we are ready to write our first ml5.js sketch! Follow [the next step to write your first sketch](/?id=your-first-sketch)!
-
-### Try ml5.js Locally
-
-Create a new folder called `/images` under your root folder, and add a bird image named `bird.png` to the `/images`.
-
-Your project directory should look something like this:
-
-```
-|_ /my-first-ml5-project
-  |_ /images
-    |_ bird.png
-  |_ index.html
-  |_ sketch.js
-```
-
-**Where**:
-
-- <img class="inline-img" src="assets/gettingstarted-open-file-folder.png" alt="folder icon" aria-hidden="true">**my-first-ml5-project/**: is the root project folder
-  - &ensp; <img class="inline-img" src="assets/gettingstarted-open-file-folder.png" alt="folder icon" aria-hidden="true">**images/**: is a folder that contains your image
-    - &ensp; &ensp; &ensp; <img class="inline-img" src="assets/gettingstarted-frame-with-picture.png" alt="image icon" aria-hidden="true"> **bird.png**: is a .png image of a bird (it can also be something else!)
-  - &ensp; <img class="inline-img" src="assets/gettingstarted-spiral-note-pad.png" alt="file icon" aria-hidden="true">**index.html**: is an .html file that has your html markup and library references
-  - &ensp; <img class="inline-img" src="assets/gettingstarted-spiral-note-pad.png" alt="file icon" aria-hidden="true">**sketch.js**: is where you'll be writing your javascript
-
-Now, we are ready to write our first ml5.js sketch! Follow [the next step to write your first sketch](/?id=your-first-sketch)!
-
-## Your First Sketch
-
-Now, no matter you are trying ml5.js online or locally, open your **sketch.js**.
-
-We can start to build your first ml5.js sketch - a classic application of machine learning: **image classification**. This application showcases how you can use a [pre-trained](https://youtu.be/yNkAuWz5lnY?si=0JuaPFYlxLFE0WSU) model called [MobileNet](https://github.com/tensorflow/tfjs-models/tree/master/mobilenet) -- a machine learning model trained to recognize the content of certain images -- in ml5.js. The application aims to highlight a general pattern for how ml5.js projects are setup.
-
-Inside your **sketch.js** file you can type out (or copy and paste) the following code. Notice in this example we have a reference to "images/bird.png". You'll replace this with the name of your image.
+Open the `sketch.js` file and define a variable called `img` to hold the image you want to classify.
 
 ```js
-let classifier;
-
-// A variable to hold the image we want to classify
 let img;
+```
 
-// Variables for displaying the results on the canvas
-let label = "";
-let confidence = "";
+Within the `preload()` function, load the image using the `loadImage()` function.
 
+```js
 function preload() {
-  // Initialize the Image Classifier method with MobileNet
   classifier = ml5.imageClassifier("MobileNet");
-  img = loadImage("images/bird.jpg");
+  img = loadImage("images/bird.png");
 }
+```
 
+## Make predictions with the model {docsify-ignore}
+In the `setup()` function, call the `classify()` function on the `classifier` object to classify the image. The `classify()` function takes two parameters: the image you want to classify and a callback function called `gotResult`.
+
+```js
 function setup() {
   createCanvas(400, 400);
   classifier.classify(img, gotResult);
-  image(img, 0, 0, width, height);
 }
+```
 
-// A function to run when we get the results
+The callback function `gotResult()` is a function that will be called when the `classify()` function finishes classifying the image. Now, let's define the `gotResult()` function.
+
+```js
 function gotResult(results) {
-  // The results are in an array ordered by confidence, print in console
+  console.log(results);
+}
+```
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true">If you are not familiar with the concept of `callback` and would like to learn more about it, check out our [ml5 Glossary](/learning/ml5-glossary) for more information._
+
+## Display the results on the canvas {docsify-ignore}
+As we discussed above, the `gotResult()` function will be called when the `classify()` function finishes classifying the image. And a variable `results` that contains the results of the classification will be passed along to `gotResult()`. Let's take a look at the `results` that is received by the `gotResult()` function.
+
+```js
+[
+  {
+    label: "robin, American robin, Turdus migratorius",
+    confidence: 0.9026526212692261
+  },
+  {
+    label: "worm fence, snake fence, snake-rail fence, Virginia fence",
+    confidence: 0.0029119430109858513
+  },
+  {
+    label: "brambling, Fringilla montifringilla",
+    confidence: 0.0015617000171914697
+  }
+]
+```
+
+The `results` is an array of objects ordered by confidence. The object at index 0 has the highest confidence. By default, ml5.js image classifier mobileNet model returns the top 3 labels with their confidence scores. In this example, we are interested in the top 1 result which has the highest confidence, which is the label has the highest probability of being correct.
+
+Define two variables `label` and `confidence` to store the label and confidence of the top 1 result.
+
+```js
+let label = "";
+let confidence = "";
+```
+
+In the `gotResult()` function, display the label and confidence of the top 1 result on the canvas using the `text()` function.
+
+```js
+function gotResult(results) {
   console.log(results);
 
-  // Display the results on the canvas
   fill(255);
   stroke(0);
   textSize(18);
@@ -199,47 +169,7 @@ function gotResult(results) {
 }
 ```
 
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with terms like **pre-trained model**, **MobileNet**, **classification**, **classifier**, **confidence** and would like to learn more about them, check out our [ml5 Glossary](/learning/ml5-glossary) for a quick intro._
-
-## Our sketch.js explained in 4 steps {docsify-ignore}
-
-### Step 1: Define your variables
-
-Here we define our variables that we will assign our classifier, image, label, and confidence to.
-
-```js
-let classifier;
-
-// A variable to hold the image we want to classify
-let img;
-
-// Variables for displaying the results on the canvas
-let label = "";
-let confidence = "";
-```
-
-### Step 2: Load your imageClassifier and image
-
-Use p5's **preload()** function to load our imageClassifier model and our bird image before running the rest of our code. Since machine learning models can be large, it can take time to load. We use **preload()** in this case to make sure our imageClassifier and image are ready to go before we can apply the image classification in the next step.
-
-```js
-function preload() {
-  classifier = ml5.imageClassifier("MobileNet");
-  img = loadImage("images/bird.png");
-}
-```
-
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with term **preload function**, check out our [ml5 Glossary](/learning/ml5-glossary) for more information._
-
-### Step 3: Setup, classify, and display
-
-In p5.js we use the **setup()** function for everything in our program that just runs once. In our program, we use the **setup()** function to:
-
-1. create a canvas to render our image
-2. call .classify() on our classifier to classify our image
-3. render the image to the canvas
-
-You will notice that the **.classify()** function takes two parameters: 1. the image you want to classify, and 2. a callback function called **gotResult**. Let's next look at what **gotResult** does.
+Lastly, render the image to the canvas using the `image()` function.
 
 ```js
 function setup() {
@@ -249,79 +179,15 @@ function setup() {
 }
 ```
 
-### Step 4: Define the gotResult() callback function
-
-The **gotResult()** function takes one parameter: the result. This parameter gets passed along to **gotResult()** when the **.classify()** function finishes classifying the image. If our classifier manages to recognize the content of the image, then a **result** will be returned.
-
-<br/>
-
-In the case of our program, we are interested in the top 1 result which has the highest confidence and stored in **results[0]**. We store the label and confidence of the result in the variables **label** and **confidence** respectively, and then display the label and confidence of the result on the canvas with the **text()** function. The **[nf()](https://p5js.org/reference/#/p5/nf)** function is a p5 function that formats our number to a nicer string.
-
-```js
-// A function to run when we get the results
-function gotResult(results) {
-  // The results are in an array ordered by confidence, print in console
-  console.log(results);
-
-  // Display the results on the canvas
-  fill(255);
-  stroke(0);
-  textSize(18);
-  label = "Label: " + results[0].label;
-  confidence = "Confidence: " + nf(results[0].confidence, 0, 2);
-  text(label, 10, 360);
-  text(confidence, 10, 380);
-}
-```
-
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with terms like **callback**, **label**, **confidence**, check out our [ml5 Glossary](/learning/ml5-glossary) for more information._
-
-## Need Help On Your Code? {docsify-ignore}
-
-Check our examples below for reference:
-
-1. If you try ml5.js online with p5 web editor, check [ml5.js image classification on p5 web editor](https://editor.p5js.org/ml5/sketches/ImageClassification)
-2. If you try ml5.js locally, check [ml5.js image classification on Github](https://github.com/ml5js/ml5-next-gen/tree/main/examples/ImageClassifier)
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with terms like `label`, `confidence` and would like to learn more about them, check out our [ml5 Glossary](/learning/ml5-glossary) for a quick intro._
 
 ## Run Your Sketch {docsify-ignore}
 
-Now, you may want to run your sketch and see if the model can make predictions and provide meaningful outputs.
-
-### Try ml5.js Online
-
-Simply press the **Play** button on the top right corner of the interface. And you should see something like this.
+Now, you may want to run your sketch and see if the model can make predictions and provide meaningful outputs. Press the run button on the top right corner of the interface. And you should see something like this.
 
 <center>
-    <img alt="screenshot of running a sketch" src="assets/gettingstarted-run-sketch.png">
+    <img alt="screenshot of running a sketch" width=`300` src="assets/gettingstarted-run-sketch.png">
 </center>
-
-### Try ml5.js Locally
-
-To run the sketch locally, we need to start a local development server.
-
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with term **local development server**, check out our [ml5 Glossary](/learning/ml5-glossary) for more information._
-
-#### Step 1. Open your terminal
-
-```sh
-# change directories to your project root directory
-cd my-first-ml5-project
-
-# start a local web server
-python3 -m http.server
-```
-
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with terms like **terminal**, **dependencies**, check out our [ml5 Glossary](/learning/ml5-glossary) for more information._
-
-#### Step 2. In a browser, open the following URL:
-
-```
-http://localhost:8000/
-```
-
-This should make your sketch show up.
-
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> You may also be interested in watching [CodingTrain - getting set up](https://www.youtube.com/watch?v=UCHzlUiDD10) for a nice intro on getting set up with writing code for the web._
 
 ## And voilà! {docsify-ignore}
 
@@ -335,13 +201,12 @@ Not all of our examples are structured exactly like this, but this provides a ta
 
 <br/>
 
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> Some guiding questions you might start to think about are:_
+Some guiding questions you might start to think about are:
+1. Do you notice that MobileNet is better at classifying some animals over others? Why do you think that is?
+2. Does the top result always accurately describe the image?
 
-_1. When classifying an image with MobileNet, does the computer see people? If not, why do you think that is?_
-_2. Do you notice that MobileNet is better at classifying some animals over others? Why do you think that is?_
+## What Next? {docsify-ignore}
 
-## What Next?
-
-Now, you have already built up your first-ever ml5.js project. Interested in using ml5.js to build more ML-based projects and would like learn more? Check out our [Next Steps](https://ml5js.github.io/ml5-website-v02-docsify/#/welcome/next-steps) page!
+Now, you have already built up your first-ever ml5.js project. Interested in using ml5.js to build more ML-based projects and would like learn more? Check out our [Next Steps](/welcome/next-steps) page!
 
 <br>

--- a/docs/learning/ml5-glossary.md
+++ b/docs/learning/ml5-glossary.md
@@ -844,7 +844,7 @@ Weights quantization is a technique used to reduce the size of a machine learnin
 ---
 
 ### Callback
-
+<!-- TODO: update content based on the new version of ml5.js -->
 ml5.js is heavily inspired by the syntax, patterns and style of the [p5.js](https://p5js.org/) library. However, there are several differences in how asynchronous operations are handled by ml5.js. ml5.js supports both <b>error-first callbacks</b> and Promises in all methods.
 
 In [p5.js](https://p5js.org/), [callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) are passed as arguments to functions that often perform some asynchronous operation. For example, [p5.js](https://p5js.org/) defines the [**loadJSON()**](https://p5js.org/reference/#/p5/loadJSON) function as the following:

--- a/docs/welcome/next-steps.md
+++ b/docs/welcome/next-steps.md
@@ -2,9 +2,12 @@
 
 If you reach this page, we assume you have successfully installed ml5.js and built your first ml5 projects following our [Getting Started](https://ml5js.github.io/ml5-website-v02-docsify/#/) page! Here are some next steps to help you continue your ml5 journey.
 
+## Explore More Fun Models
+During the Getting Started guide, you have used ml5 [Image Classifier](/reference/image-classifier) to classify images. ml5.js provides a variety of pre-trained models that you can use to build your projects. Check out the [Reference](/reference/overview) page to explore more models and their functionalities.
+
 ## Learn ML
 
-Interested in using ml5.js to build more ML-based projects? Check out these learning resources!
+If you would like to understand how the machine learning models work behind the scenes, we recommend you to learn more about theory of machine learning algorithms. Here are some resources to help you get started:
 
 > #### Beginner's Guide to Machine Learning with ml5.js 👉[ Learn](https://youtu.be/26uABexmOX4?si=nqPoD6bQrVTU-YFw) _By Daniel Shiffman_
 >


### PR DESCRIPTION
Updates in this PR:
1. remove "run ml5 locally" from getting started page
2. rewrite the getting started page, with no sales tone, use alpha version code, and step-by-step guidance on the functionality of each line of code (tutorial style).

To-do:
1. replace all images with standard size (need photoshop) + use highlight frame instead of arrow for accessibility + take screenshots using alpha version, and then use width = 800 for all.

@shiffman @MOQN Hi Dan, Moon, please let me know if anything needs further adjustment. Thank you!!