### PR TITLE
Myrah bodypose content rewording

### DIFF
--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -7,298 +7,89 @@
 
 ## Description
 
-Bodypose offers a versatile solution for pose estimation by leveraging the strengths of Movenet and Blazepose. It provides real-time, full-body pose estimation and precise tracking of key body parts, including hands, face, and body, in an optimized and lightweight package.
+ml5.js Bodypose is a pretrained pose estimation model that offers the flexibility to:
+1. Estimate poses for single or multiple persons.
+2. Estimate poses from images or videos.
+3. Choose between MoveNet (17 keypoints, optimized for speed) and BlazePose models (33 keypoints, optimized for precision).
 
-### Key Features
+ml5.js Bodypose is developed leveraging [MoveNet](https://www.tensorflow.org/hub/tutorials/movenet#:~:text=MoveNet%20is%20an%20ultra%20fast,known%20as%20Lightning%20and%20Thunder) and [Blazepose](https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker) models.
 
-- **High-precision keypoints tracking**: Detects and tracks key body parts with high accuracy
-- **Multi-person pose estimation**: Supports multiple people in the frame
-- **Lightweight and optimized for performance**: Speed and efficiency for real-time applications
-
-### What can we do with the model?
-
-Bodypose is suitable for a wide range of applications, such as interactive gaming, fitness apps, art installations, and accessibility solutions. Its accuracy and real-time performance make it a valuable tool for developers and creators!
-
-Bodypose's MoveNet model predict a set of 17 keypoints:
-
-> Nose, Left Eye, Right Eye, Left Ear, Right Ear, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle
-
-See the diagram below for the position of each keypoint.
-
-  <center>
-      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/c3641b718d7e613b2ce111a6a4575e88ca35a60cb325efdd9113c453b2a09301/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d6f76656e65742f636f636f2d6b6579706f696e74732d3530302e706e67">
-  </center>
-
-Bodypose's Blazepose model predict a set of 33 keypoints:
-
-> Nose, Left Eye Inner, Left Eye, Left Eye Outer, Right Eye Inner, Right Eye, Right Eye Outer, Left Ear, Right Ear, Mouth Left, Mouth Right, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Pinky, Right Pinky, Left Index, Right Index, Left Thumb, Right Thumb, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle, Left Heel, Right Heel, Left Foot Index, Right Foot Index, Body Center, Forehead, Left Thumb, Left Hand, Right Thumb, Right Hand
-
-See the diagram below for the position of each keypoint.
-
-  <center>
-      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/17082997c33fc6d2544c4aea33d9898860cf902ed5a0b865527d1dd91bbc7efa/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d65646961706970652f626c617a65706f73652d6b6579706f696e74732d757064617465642e706e67">
-  </center>
-
-Once you have the keypoints estimated by the model, you can utilize them in various ways based on your application:
-
-**Human Pose Estimation**: You can reconstruct the human body pose by connecting the keypoints using skeletal connections. This helps visualize the pose and track the movement of body parts.
-
-**Gesture Recognition**: By analyzing the relative positions and movements of keypoints over time, you can recognize specific gestures or actions performed by a person.
-
-**Fitness Tracking**: PoseNet/MoveNet can be used to track exercises and provide feedback on the correctness of the exercise form. For instance, it can help ensure that a person is maintaining proper alignment during yoga poses or weightlifting.
-
-**Augmented Reality**: Keypoints can be used to anchor virtual objects or effects to specific body parts, allowing for interactive augmented reality experiences.
-
-**Biomechanics Analysis**: In sports and rehabilitation, PoseNet/MoveNet can provide insights into body movements, helping to analyze techniques, prevent injuries, and aid in recovery.
-
-**Accessibility**: Bodypos can be used to track body movements and gestures to control devices and interfaces, enabling people with disabilities to interact with technology in new ways.
-
-### Output Example
-
-An example of the output from Body Pose MoveNet model is shown below:
-
-```javascript
-[
-  {
-    keypoints: [
-      {
-        y: 64.88419532775879,
-        x: 381.0333251953125,
-        score: 0.7116302847862244,
-        name: "nose",
-      },
-      // Additional keypoints here...
-    ],
-    box: {
-      yMin: 0.004535397049039602,
-      xMin: 0.06256416440010071,
-      yMax: 0.9879268407821655,
-      xMax: 0.9208574295043945,
-      width: 0.8582932651042938,
-      height: 0.9833914437331259,
-    },
-    score: 0.3704647719860077,
-    id: 4,
-    nose: {
-      x: 381.0333251953125,
-      y: 64.88419532775879,
-      score: 0.7116302847862244,
-    },
-    left_eye: {
-      /* Properties of the left eye */
-    },
-    right_eye: {
-      /* Properties of the right eye */
-    },
-    left_ear: {
-      /* Properties of the left ear */
-    },
-    right_ear: {
-      /* Properties of the right ear */
-    },
-    left_shoulder: {
-      /* Properties of the left shoulder */
-    },
-    right_shoulder: {
-      /* Properties of the right shoulder */
-    },
-    left_elbow: {
-      /* Properties of the left elbow */
-    },
-    right_elbow: {
-      /* Properties of the right elbow */
-    },
-    left_wrist: {
-      /* Properties of the left wrist */
-    },
-    right_wrist: {
-      /* Properties of the right wrist */
-    },
-    left_hip: {
-      /* Properties of the left hip */
-    },
-    right_hip: {
-      /* Properties of the right hip */
-    },
-    left_knee: {
-      /* Properties of the left knee */
-    },
-    right_knee: {
-      /* Properties of the right knee */
-    },
-    left_ankle: {
-      /* Properties of the left ankle */
-    },
-    right_ankle: {
-      /* Properties of the right ankle */
-    },
-  },
-  // Additional objects here...
-];
-```
-
-An example of the output from Body Pose Blazepose model is shown below:
-
-```javascript
-[
-  {
-    keypoints: [
-      {
-        x: 384.1078567504883,
-        y: 209.4658613204956,
-        z: -0.35329264402389526,
-        score: 0.9999341368675232,
-        name: "nose",
-      },
-      // Additional keypoints here...
-    ],
-    keypoints3D: [
-      {
-        x: -0.08051524311304092,
-        y: -0.6131212711334229,
-        z: -0.3431171476840973,
-        score: 0.9999341368675232,
-        name: "nose",
-      },
-      // Additional 3D keypoints here...
-    ],
-    nose: {
-      x: 384.1078567504883,
-      y: 209.4658613204956,
-      z: -0.35329264402389526,
-      score: 0.9999341368675232,
-    },
-    left_eye_inner: {
-      /* Properties of the left eye inner */
-    },
-    left_eye: {
-      /* Properties of the left eye */
-    },
-    left_eye_outer: {
-      /* Properties of the left eye outer */
-    },
-    right_eye_inner: {
-      /* Properties of the right eye inner */
-    },
-    right_eye: {
-      /* Properties of the right eye */
-    },
-    right_eye_outer: {
-      /* Properties of the right eye outer */
-    },
-    left_ear: {
-      /* Properties of the left ear */
-    },
-    right_ear: {
-      /* Properties of the right ear */
-    },
-    mouth_left: {
-      /* Properties of the mouth left */
-    },
-    mouth_right: {
-      /* Properties of the mouth right */
-    },
-    left_shoulder: {
-      /* Properties of the left shoulder */
-    },
-    right_shoulder: {
-      /* Properties of the right shoulder */
-    },
-    left_elbow: {
-      /* Properties of the left elbow */
-    },
-    right_elbow: {
-      /* Properties of the right elbow */
-    },
-    left_wrist: {
-      /* Properties of the left wrist */
-    },
-    right_wrist: {
-      /* Properties of the right wrist */
-    },
-    left_pinky: {
-      /* Properties of the left pinky */
-    },
-    right_pinky: {
-      /* Properties of the right pinky */
-    },
-    left_index: {
-      /* Properties of the left index finger */
-    },
-    right_index: {
-      /* Properties of the right index finger */
-    },
-    left_thumb: {
-      /* Properties of the left thumb */
-    },
-    right_thumb: {
-      /* Properties of the right thumb */
-    },
-    left_hip: {
-      /* Properties of the left hip */
-    },
-    right_hip: {
-      /* Properties of the right hip */
-    },
-    left_knee: {
-      /* Properties of the left knee */
-    },
-    right_knee: {
-      /* Properties of the right knee */
-    },
-    left_ankle: {
-      /* Properties of the left ankle */
-    },
-    right_ankle: {
-      /* Properties of the right ankle */
-    },
-    left_heel: {
-      /* Properties of the left heel */
-    },
-    right_heel: {
-      /* Properties of the right heel */
-    },
-    left_foot_index: {
-      /* Properties of the left foot index */
-    },
-    right_foot_index: {
-      /* Properties of the right foot index */
-    },
-  },
-  // Additional objects here...
-];
-```
-
-## Getting Started
-
-Integrating Bodypose into your ml5.js projects is straightforward. Our documentation and user-friendly API will help you make the most of this combined model!
-
-### Demo
-
+## Demo
 [DEMO](iframes/pose-estimation ":include :type=iframe width=100% height=550px")
 
-### Quick Start
+## Quick Start
+Try [this BodyPose example in the p5.js web editor](https://editor.p5js.org/ml5/sketches/vpSI23x0A)! Press the run button to see the code in action.
 
-Before you start, let's create an empty project in the [p5 web editor](https://editor.p5js.org/).
+This example is built on the same source code as the [demo](/reference/bodypose?id=demo) above. It uses the MoveNet model (default model if not specified by user) to detect body poses in real-time from the webcam video. The detected keypoints are then visualized on the canvas. To understand the code in detail, follow the [How to](/reference/bodypose?id=how-to) tutorial below.
 
-First of all, copy and paste the following code into your **index.html** file. If you are not familiar with the p5 web editor interface, you can find a guide on how to find your **index.html** file [here](/?id=try-ml5js-online-1).
+## How to
+This tutorial is a p5.js sketch running on [p5.js web editor](https://editor.p5js.org/). To follow this tutorial, create an empty project on the p5.js web editor.
+
+### Set up ml5.js
+Import the ml5.js library in your HTML file.
 
 ```html
 <script src="https://unpkg.com/ml5@alpha/dist/ml5.js"></script>
 ```
 
-Then, add the code below to your **sketch.js** file:
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with how to import ml5.js library and need more detailed guidance, please check out our [Getting Started](/?id=set-up-ml5js) tutorial._
 
-```js
-let video;
+### Load model
+Open the `sketch.js`. Define a variable to hold the bodypose model.
+
+```javascript
 let bodyPose;
-let poses = [];
+```
 
+Create a `preload()` function to load the bodypose model.
+
+```javascript
 function preload() {
-  // Load the bodyPose model, default is MoveNet model
+  // Load the bodyPose model
   bodyPose = ml5.bodyPose();
 }
+```
 
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> Here you could also pass model name, an options object, and a customized callback function to the `ml5.bodyPose()` function (e.g. `ml5.bodyPose('BlazePose', options, modelLoaded)`) to change the default configuration of the model. For more information on the available configuration settings, refer to the [Methods](/reference/bodypose?id=ml5bodypose) section below._
+
+### Fetch webcam video
+Define a variable `video` to hold the webcam video.
+
+```javascript
+let video;
+```
+
+Resize the canvas to dimensions 640x480, a common resolution for webcams.
+
+```javascript
+function setup() {
+  createCanvas(640, 480);
+}
+```
+
+Fetch the webcam video, resize it to fit the canvas, and hide it from the display.
+
+```javascript
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+}
+```
+
+### Detect poses in the webcam video with the model
+Define a variable `poses` to hold the detected poses.
+
+```javascript
+let poses = [];
+```
+
+Start detecting poses in the webcam video by calling the `bodyPose.detectStart()` method. Here, we pass two parameters: the webcam video and a customized callback function `gotPoses`.
+
+```javascript
 function setup() {
   createCanvas(640, 480);
 
@@ -310,10 +101,207 @@ function setup() {
   // Start detecting poses in the webcam video
   bodyPose.detectStart(video, gotPoses);
 }
+```
 
+The `gotPoses()` function is a callback function that will be called when the `bodyPose.detectStart()` method dectects poses. Once the poses are detected, the output `results` will be passed to `gotPoses()`, and then saved to the `poses` variable.
+
+```javascript
+function gotPoses(results) {
+  // Save the output to the poses variable
+  poses = results;
+}
+```
+
+### Draw skeleton on the canvas
+In the `draw()` function, draw the webcam video on the canvas.
+
+```javascript
 function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
+}
+```
+
+Draw the skeleton by connecting the keypoints of the detected poses with lines. To achieve this, we need to understand which keypoints are connected to each other. Define a variable `connections` to hold the skeleton connections.
+
+
+```javascript
+let connections;
+```
+
+Use `bodyPose.getSkeleton()` to get the connections between keypoints. This method returns an array of arrays, where each sub-array contains the indices of the connected keypoints. For example, `[[0, 1], [0, 2], ...]` means that keypoints 0 (Nose) and 1 (Left Eye) are connected, keypoints 0 (Nose) and 2 (Right Eye) are connected, and so on.
+
+```javascript
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+
+  // Start detecting poses in the webcam video
+  bodyPose.detectStart(video, gotPoses);
+  //get the skeleton connection information
+  connections = bodyPose.getSkeleton();
+}
+```
+
+Then, we can draw the skeleton by connecting the keypoints with lines. We iterate through the `poses` array, where each object `pose` is a pose of a person, containing an array of `keypoints`. Each `keypoint` object has properties `x`, `y`, and `score`. The `score` is the confidence score of the keypoint prediction.
+  
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+  }
+}
+```
+
+Within each pose, we only want to draw the skeleton connections that the model has a high confidence in predicting. To achieve this, we need to check for each link in the `connections` array whether the `keypoints` that constitute the link have a confidence `score` greater than 0.1. If they do, we draw a line connecting the keypoints.
+
+We iterate through the connections array, and each item is a link of `pointA` and `pointB`. For instance, `connections[1]` is `[0, 2]`, where 0 is the index of `pointA` and 2 is the index of `pointB`. Thus, `let pointAIndex = connections[j][0];` means we get the starting point (pointA) of the link j, and `let pointBIndex = connections[j][1];` means we get the ending point (pointB) of the link j.
+
+Now we can use the indices to retrieve the `pointA` and `pointB` objects from the `pose.keypoints`. `pointA` is a object with properties `x`, `y`, and `score`.
+
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+    }
+  }
+}
+```
+
+Now, we can draw the line connecting the keypoints if both points have a confidence score greater than 0.1.
+
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
+}
+```
+
+### Draw keypoints on the canvas
+Iterate through the `poses` array and draw a circle for each keypoint if the confidence score is greater than 0.1.
+
+We can get each person's pose from the `poses` array. Each `pose` object contains an array of `keypoints`.
+
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+  }
+}
+```
+
+Now we iterate through all the keypoints in the `keypoints`. Each `keypoint` object has properties `x`, `y`, and `score`. The `score` is the confidence score of the keypoint prediction.
+  
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < pose.keypoints.length; j++) {
+      let keypoint = pose.keypoints[j];
+    }
+  }
+}
+```
+
+For each keypoint, we only want to draw a circle if the keypoint's confidence is greater than 0.1. We can use the `score` property of the keypoint object to check the confidence score.
+
+```javascript
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
 
   // Draw all the tracked landmark points
   for (let i = 0; i < poses.length; i++) {
@@ -329,30 +317,17 @@ function draw() {
     }
   }
 }
-
-// Callback function for when bodyPose outputs data
-function gotPoses(results) {
-  // Save the output to the poses variable
-  poses = results;
-}
 ```
 
-Alternatively, you can open [this example code](https://github.com/ml5js/ml5-next-gen/tree/main/examples/BodyPose-keypoints) and try it yourself on p5.js web editor!
-
-### Additional Examples
-
-- [BodyPose-blazepose-keypoints](https://github.com/ml5js/ml5-next-gen/tree/main/examples/BodyPose-blazepose-keypoints): Draw the body keypoints of the detected body using Blazepose model.
-
-<!-- ### Tutorials
-
-**PoseNet on The Coding Train**
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/OIo-DIOkNVg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
+## Examples
+- [BodyPose-blazepose-keypoints](https://editor.p5js.org/ml5/sketches/OukJYAJAb): Draw the body keypoints of the detected body using Blazepose model.
 
 ## Methods
-
 #### ml5.bodypose()
 
 This method is used to initialize the bodypose object.
+
+<!-- TODO: Add default model name, and explain the options, callback. -->
 
 ```javascript
 const bodypose = ml5.bodypose(?options, ?callback);
@@ -411,6 +386,41 @@ bodypose.detectStart(media, callback);
     ...
   ];
   ```
+
+  Bodypose's MoveNet model predict a set of 17 keypoints: Nose, Left Eye, Right Eye, Left Ear, Right Ear, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle
+
+  See the diagram below for the position of each keypoint.
+
+  <center>
+      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/c3641b718d7e613b2ce111a6a4575e88ca35a60cb325efdd9113c453b2a09301/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d6f76656e65742f636f636f2d6b6579706f696e74732d3530302e706e67">
+  </center>
+
+  Bodypose's Blazepose model predict a set of 33 keypoints: Nose, Left Eye Inner, Left Eye, Left Eye Outer, Right Eye Inner, Right Eye, Right Eye Outer, Left Ear, Right Ear, Mouth Left, Mouth Right, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Pinky, Right Pinky, Left Index, Right Index, Left Thumb, Right Thumb, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle, Left Heel, Right Heel, Left Foot Index, Right Foot Index, Body Center, Forehead, Left Thumb, Left Hand, Right Thumb, Right Hand
+
+  See the diagram below for the position of each keypoint.
+
+  <center>
+      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/17082997c33fc6d2544c4aea33d9898860cf902ed5a0b865527d1dd91bbc7efa/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d65646961706970652f626c617a65706f73652d6b6579706f696e74732d757064617465642e706e67">
+  </center>
+
+  ```javascript
+  [
+    {
+      box: { width, height, xMax, xMin, yMax, yMin },
+      id: 1,
+      keypoints: [{ x, y, z, score, name }, ...],
+      keypoints3D: [{ x, y, z, score, name }, ...],
+      left_ankle: { x, y, z, confidence },
+      left_ear: { x, y, z, confidence },
+      left_elbow: { x, y, z, confidence },
+      ...
+      score: 0.28,
+    },
+    ...
+  ];
+  ```
+
+  _<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> The `keypoints3D` array contains the 3D coordinates of the keypoints. The `z` property represents the depth of the keypoint. The 2D `keypoints` still includes a Z-coordinate to provide additional depth information and helps understand the relative positioning of body parts, enhancing the accuracy of applications that primarily work with 2D data._
 
 #### bodypose.detectStop()
 

--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -1,4 +1,4 @@
-# Bodypose
+# BodyPose
 
 <center>
     <img style="display:block; max-width:100%" alt="pose estimation" src="https://1.bp.blogspot.com/-25aGTL-RTnY/YJ29jgiiNHI/AAAAAAAAEMM/9qJC_xqlUKo4To9xyumqKmrqKr-vVFXzgCLcBGAsYHQ/s0/three_pane_aligned%2B%25281%2529.gif">
@@ -7,41 +7,47 @@
 
 ## Description
 
-ml5.js Bodypose is a pretrained pose estimation model that offers the flexibility to:
-1. Estimate poses for single or multiple persons.
-2. Estimate poses from images or videos.
-3. Choose between MoveNet (17 keypoints, optimized for speed) and BlazePose models (33 keypoints, optimized for precision).
+ml5.js bodyPose is a pretrained pose estimation model that can estimate poses and track key body parts in real-time. It is developed leveraging TensorFlow's [MoveNet](https://www.tensorflow.org/hub/tutorials/movenet#:~:text=MoveNet%20is%20an%20ultra%20fast,known%20as%20Lightning%20and%20Thunder) and [Blazepose](https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker) models.
 
-ml5.js Bodypose is developed leveraging [MoveNet](https://www.tensorflow.org/hub/tutorials/movenet#:~:text=MoveNet%20is%20an%20ultra%20fast,known%20as%20Lightning%20and%20Thunder) and [Blazepose](https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker) models.
+It offers flexibility for:
+
+- **Multi-person detection**: Estimate poses for single or multiple people in the frame.
+- **Video and image inputs**: Estimate poses from both images and live or recorded videos.
+- **Choose between two models**: MoveNet (17 keypoints, optimized for speed) and BlazePose (33 keypoints, optimized for precision).
 
 ## Demo
+
 [DEMO](iframes/pose-estimation ":include :type=iframe width=100% height=550px")
 
-## Quick Start
-Try [this BodyPose example in the p5.js web editor](https://editor.p5js.org/ml5/sketches/vpSI23x0A)! Press the run button to see the code in action.
+This bodyPose example uses the MoveNet model (default model if not specified by user) to detect body poses in real-time from the webcam video. The detected keypoints are then visualized on the canvas.
 
-This example is built on the same source code as the [demo](/reference/bodypose?id=demo) above. It uses the MoveNet model (default model if not specified by user) to detect body poses in real-time from the webcam video. The detected keypoints are then visualized on the canvas. To understand the code in detail, follow the [How to](/reference/bodypose?id=how-to) tutorial below.
+You can also [open the demo in the p5.js web editor](https://editor.p5js.org/ml5/sketches/vpSI23x0A), and then press the run button to see the code in action!
 
-## How to
-This tutorial is a p5.js sketch running on [p5.js web editor](https://editor.p5js.org/). To follow this tutorial, create an empty project on the p5.js web editor.
+To understand the code in detail, take a look at the following tutorial.
+
+## Tutorial
+
+This step-by-step guide uses a p5.js sketch running on the [p5.js web editor](https://editor.p5js.org/). To follow along, start by creating an empty project in the editor.
 
 ### Set up ml5.js
-Import the ml5.js library in your HTML file.
+
+Import the ml5.js library in your `index.html` file.
 
 ```html
 <script src="https://unpkg.com/ml5@alpha/dist/ml5.js"></script>
 ```
 
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with how to import ml5.js library and need more detailed guidance, please check out our [Getting Started](/?id=set-up-ml5js) tutorial._
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> If you are not familiar with how to import the ml5.js library and need more detailed guidance, please check out our [Getting Started](/?id=set-up-ml5js) tutorial._
 
 ### Load model
-Open the `sketch.js`. Define a variable to hold the bodypose model.
+
+Open the `sketch.js` file. Define a variable to hold the bodyPose model.
 
 ```javascript
 let bodyPose;
 ```
 
-Create a `preload()` function to load the bodypose model.
+Create a `preload()` function to load the bodyPose model.
 
 ```javascript
 function preload() {
@@ -50,16 +56,17 @@ function preload() {
 }
 ```
 
-_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> Here you could also pass model name, an options object, and a customized callback function to the `ml5.bodyPose()` function (e.g. `ml5.bodyPose('BlazePose', options, modelLoaded)`) to change the default configuration of the model. For more information on the available configuration settings, refer to the [Methods](/reference/bodypose?id=ml5bodypose) section below._
+_<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> You can also pass a model name, an options object, and a customized callback function to the `ml5.bodyPose()` function (e.g., `ml5.bodyPose('BlazePose', options, modelLoaded)`) to change the default configuration of the model. For more information on the available configuration settings, refer to the [Methods](/reference/bodypose?id=ml5bodypose) section on this page._
 
 ### Fetch webcam video
+
 Define a variable `video` to hold the webcam video.
 
 ```javascript
 let video;
 ```
 
-Resize the canvas to dimensions 640x480, a common resolution for webcams.
+Resize the canvas dimensions to 640x480, a common resolution for webcams.
 
 ```javascript
 function setup() {
@@ -80,14 +87,15 @@ function setup() {
 }
 ```
 
-### Detect poses in the webcam video with the model
+### Detect poses
+
 Define a variable `poses` to hold the detected poses.
 
 ```javascript
 let poses = [];
 ```
 
-Start detecting poses in the webcam video by calling the `bodyPose.detectStart()` method. Here, we pass two parameters: the webcam video and a customized callback function `gotPoses`.
+To start detecting poses in the webcam video, call the `bodyPose.detectStart()` method. Here, we pass two parameters: the webcam video and a customized callback function `gotPoses`.
 
 ```javascript
 function setup() {
@@ -103,7 +111,7 @@ function setup() {
 }
 ```
 
-The `gotPoses()` function is a callback function that will be called when the `bodyPose.detectStart()` method dectects poses. Once the poses are detected, the output `results` will be passed to `gotPoses()`, and then saved to the `poses` variable.
+The `gotPoses()` function is a callback function that will be called when the `bodyPose.detectStart()` method detects poses. Once the poses are detected, the output `results` will be passed to `gotPoses()`, and then saved to the `poses` variable.
 
 ```javascript
 function gotPoses(results) {
@@ -113,6 +121,7 @@ function gotPoses(results) {
 ```
 
 ### Draw skeleton on the canvas
+
 In the `draw()` function, draw the webcam video on the canvas.
 
 ```javascript
@@ -122,14 +131,13 @@ function draw() {
 }
 ```
 
-Draw the skeleton by connecting the keypoints of the detected poses with lines. To achieve this, we need to understand which keypoints are connected to each other. Define a variable `connections` to hold the skeleton connections.
-
+We can draw the skeleton by connecting the keypoints of the detected poses with lines. To achieve this, we first need to understand which keypoints are connected to each other. Define a variable `connections` to hold the skeleton connections.
 
 ```javascript
 let connections;
 ```
 
-Use `bodyPose.getSkeleton()` to get the connections between keypoints. This method returns an array of arrays, where each sub-array contains the indices of the connected keypoints. For example, `[[0, 1], [0, 2], ...]` means that keypoints 0 (Nose) and 1 (Left Eye) are connected, keypoints 0 (Nose) and 2 (Right Eye) are connected, and so on.
+Use `bodyPose.getSkeleton()` in the `setup()` function to get the connections between keypoints. This method returns an array of arrays, where each sub-array contains the indices of the connected keypoints. For example, `[[0, 1], [0, 2], ...]` means that keypoints 0 (Nose) and 1 (Left Eye) are connected, keypoints 0 (Nose) and 2 (Right Eye) are connected, and so on.
 
 ```javascript
 function setup() {
@@ -142,37 +150,37 @@ function setup() {
 
   // Start detecting poses in the webcam video
   bodyPose.detectStart(video, gotPoses);
-  //get the skeleton connection information
+  // Get the skeleton connection information
   connections = bodyPose.getSkeleton();
 }
 ```
 
-Then, we can draw the skeleton by connecting the keypoints with lines. We iterate through the `poses` array, where each object `pose` is a pose of a person, containing an array of `keypoints`. Each `keypoint` object has properties `x`, `y`, and `score`. The `score` is the confidence score of the keypoint prediction.
-  
+Next, we can start drawing the skeleton connections. We iterate through the `poses` array, where each object `pose` is a pose of a person, containing an array of `keypoints`. Each `keypoint` object has the properties `x`, `y`, and `score`. The `score` is the confidence score of the keypoint prediction.
+
 ```javascript
 function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
   }
 }
 ```
 
-Within each pose, we only want to draw the skeleton connections that the model has a high confidence in predicting. To achieve this, we need to check for each link in the `connections` array whether the `keypoints` that constitute the link have a confidence `score` greater than 0.1. If they do, we draw a line connecting the keypoints.
+Within each pose, we only want to draw the skeleton connections that the model has a high confidence in predicting. To do this, we need to check for each link in the `connections` array and whether the `keypoints` that constitute the link have a confidence `score` greater than 0.1. If they do, we draw a line connecting the keypoints.
 
-We iterate through the connections array, and each item is a link of `pointA` and `pointB`. For instance, `connections[1]` is `[0, 2]`, where 0 is the index of `pointA` and 2 is the index of `pointB`. Thus, `let pointAIndex = connections[j][0];` means we get the starting point (pointA) of the link j, and `let pointBIndex = connections[j][1];` means we get the ending point (pointB) of the link j.
+We iterate through the connections array, with each item being a link of `pointA` and `pointB`. For instance, `connections[1]` is `[0, 2]`, where 0 is the index of `pointA` and 2 is the index of `pointB`. Thus, `let pointAIndex = connections[j][0];` means we get the starting point (pointA) of the link `j`, and `let pointBIndex = connections[j][1];` means we get the ending point (pointB) of the link `j`.
 
-Now we can use the indices to retrieve the `pointA` and `pointB` objects from the `pose.keypoints`. `pointA` is a object with properties `x`, `y`, and `score`.
+Use the indices to retrieve the `pointA` and `pointB` objects from the `pose.keypoints`. As with all keypoints, `pointA` is an object with properties `x`, `y`, and `score`.
 
 ```javascript
 function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
     for (let j = 0; j < connections.length; j++) {
@@ -192,7 +200,7 @@ function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
     for (let j = 0; j < connections.length; j++) {
@@ -212,7 +220,8 @@ function draw() {
 ```
 
 ### Draw keypoints on the canvas
-Iterate through the `poses` array and draw a circle for each keypoint if the confidence score is greater than 0.1.
+
+We can also represent each of the keypoints on the canvas. To do this, we will iterate through the `poses` array and draw a circle for each keypoint if the confidence score is greater than 0.1.
 
 We can get each person's pose from the `poses` array. Each `pose` object contains an array of `keypoints`.
 
@@ -221,7 +230,7 @@ function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
     for (let j = 0; j < connections.length; j++) {
@@ -245,14 +254,14 @@ function draw() {
 }
 ```
 
-Now we iterate through all the keypoints in the `keypoints`. Each `keypoint` object has properties `x`, `y`, and `score`. The `score` is the confidence score of the keypoint prediction.
-  
+Next, we iterate through all of the keypoints in `keypoints`.
+
 ```javascript
 function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
     for (let j = 0; j < connections.length; j++) {
@@ -286,7 +295,7 @@ function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
 
-  //draw the skeleton connections
+  // Draw the skeleton connections
   for (let i = 0; i < poses.length; i++) {
     let pose = poses[i];
     for (let j = 0; j < connections.length; j++) {
@@ -320,12 +329,14 @@ function draw() {
 ```
 
 ## Examples
-- [BodyPose-blazepose-keypoints](https://editor.p5js.org/ml5/sketches/OukJYAJAb): Draw the body keypoints of the detected body using Blazepose model.
+
+- [bodyPose BlazePose keypoints](https://editor.p5js.org/ml5/sketches/OukJYAJAb): Draw the keypoints of the detected body using BlazePose model.
 
 ## Methods
-#### ml5.bodypose()
 
-This method is used to initialize the bodypose object.
+### ml5.bodypose()
+
+This method is used to initialize the bodyPose object.
 
 <!-- TODO: Add default model name, and explain the options, callback. -->
 
@@ -351,16 +362,16 @@ const bodypose = ml5.bodypose(?options, ?callback);
   }
   ```
 
-  More info on options [here](https://github.com/tensorflow/tfjs-models/tree/master/pose-detection/src/movenet#create-a-detector).
+  See the [MoveNet documentation](https://github.com/tensorflow/tfjs-models/tree/master/pose-detection/src/movenet#create-a-detector) for more information on options.
 
-- **callback(bodypose, error)**: OPTIONAL. A function to run once the model has been loaded. Alternatively, call `ml5.bodyPix()` within the p5 `preload` function.
+- **callback(bodypose, error)**: OPTIONAL. A function to run once the model has been loaded. Alternatively, call `ml5.bodyPix()` within the p5.js `preload` function.
 
 **Returns:**  
-The bodypose object.
+The bodyPose object.
 
-#### bodypose.detectStart()
+### bodypose.detectStart()
 
-This method repeatedly outputs pose estimations on an image media through a callback function.
+This method continuously outputs pose estimations on an image media through a callback function.
 
 ```javascript
 bodypose.detectStart(media, callback);
@@ -387,20 +398,24 @@ bodypose.detectStart(media, callback);
   ];
   ```
 
-  Bodypose's MoveNet model predict a set of 17 keypoints: Nose, Left Eye, Right Eye, Left Ear, Right Ear, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle
+  BodyPose's MoveNet model predicts a set of 17 keypoints:
+
+  Nose, Left Eye, Right Eye, Left Ear, Right Ear, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle
 
   See the diagram below for the position of each keypoint.
 
   <center>
-      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/c3641b718d7e613b2ce111a6a4575e88ca35a60cb325efdd9113c453b2a09301/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d6f76656e65742f636f636f2d6b6579706f696e74732d3530302e706e67">
-  </center>
+      <img style="display:block; max-width:30%" alt="MoveNet keypoint diagram" src="https://camo.githubusercontent.com/c3641b718d7e613b2ce111a6a4575e88ca35a60cb325efdd9113c453b2a09301/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d6f76656e65742f636f636f2d6b6579706f696e74732d3530302e706e67">
+  </center> <br/>
 
-  Bodypose's Blazepose model predict a set of 33 keypoints: Nose, Left Eye Inner, Left Eye, Left Eye Outer, Right Eye Inner, Right Eye, Right Eye Outer, Left Ear, Right Ear, Mouth Left, Mouth Right, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Pinky, Right Pinky, Left Index, Right Index, Left Thumb, Right Thumb, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle, Left Heel, Right Heel, Left Foot Index, Right Foot Index, Body Center, Forehead, Left Thumb, Left Hand, Right Thumb, Right Hand
+  BodyPose's BlazePose model predicts a set of 33 keypoints:
+
+  Nose, Left Eye Inner, Left Eye, Left Eye Outer, Right Eye Inner, Right Eye, Right Eye Outer, Left Ear, Right Ear, Mouth Left, Mouth Right, Left Shoulder, Right Shoulder, Left Elbow, Right Elbow, Left Wrist, Right Wrist, Left Pinky, Right Pinky, Left Index, Right Index, Left Thumb, Right Thumb, Left Hip, Right Hip, Left Knee, Right Knee, Left Ankle, Right Ankle, Left Heel, Right Heel, Left Foot Index, Right Foot Index, Body Center, Forehead, Left Thumb, Left Hand, Right Thumb, Right Hand
 
   See the diagram below for the position of each keypoint.
 
   <center>
-      <img style="display:block; max-width:30%" alt="Keypoint Diagram" src="https://camo.githubusercontent.com/17082997c33fc6d2544c4aea33d9898860cf902ed5a0b865527d1dd91bbc7efa/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d65646961706970652f626c617a65706f73652d6b6579706f696e74732d757064617465642e706e67">
+      <img style="display:block; max-width:30%" alt="BlazePose keypoint diagram" src="https://camo.githubusercontent.com/17082997c33fc6d2544c4aea33d9898860cf902ed5a0b865527d1dd91bbc7efa/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f6d65646961706970652f626c617a65706f73652d6b6579706f696e74732d757064617465642e706e67">
   </center>
 
   ```javascript
@@ -420,9 +435,9 @@ bodypose.detectStart(media, callback);
   ];
   ```
 
-  _<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> The `keypoints3D` array contains the 3D coordinates of the keypoints. The `z` property represents the depth of the keypoint. The 2D `keypoints` still includes a Z-coordinate to provide additional depth information and helps understand the relative positioning of body parts, enhancing the accuracy of applications that primarily work with 2D data._
+  _<img class="inline-img" src="assets/gettingstarted-bulb.png" alt="tip icon" aria-hidden="true"> The `keypoints3D` array contains the 3D coordinates of the keypoints, with the `z` property representing the depth of each keypoint. The 2D `keypoints` still include z-coordinates to provide additional depth information. This helps in understanding the relative positioning of body parts, enhancing the accuracy of applications that primarily work with 2D data._
 
-#### bodypose.detectStop()
+### bodypose.detectStop()
 
 This method can be called after a call to `bodypose.detectStart` to stop the repeating pose estimation.
 
@@ -430,7 +445,7 @@ This method can be called after a call to `bodypose.detectStart` to stop the rep
 bodypose.detectStop();
 ```
 
-#### bodypose.detect()
+### bodypose.detect()
 
 This method asynchronously outputs a single pose estimation on an image media when called.
 

--- a/docs/reference/iframes/pose-estimation/index.html
+++ b/docs/reference/iframes/pose-estimation/index.html
@@ -16,7 +16,7 @@
   <script>
     // Navbar will be added on the top of the page.
     // You can provide a link to the script file on the p5 web editor.
-    navbar("");
+    navbar("https://editor.p5js.org/ml5/sketches/vpSI23x0A");
   </script>
 
   <iframe src="ready.html" name="script-iframe"></iframe>>

--- a/docs/reference/iframes/pose-estimation/ready.html
+++ b/docs/reference/iframes/pose-estimation/ready.html
@@ -14,7 +14,7 @@
 <body>
   <div class="content-container">
     <h1>Body Pose Keypoints Detection Model</h1>
-    <p>Instructions</p>
+    <p>Please allow the browser to turn on the web camera.</p>
   </div>
 </body>
 

--- a/docs/reference/iframes/pose-estimation/script.js
+++ b/docs/reference/iframes/pose-estimation/script.js
@@ -1,11 +1,15 @@
-// Copyright (c) 2018-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates drawing skeletons on poses for the MoveNet model.
+ */
 
 let video;
 let bodyPose;
 let poses = [];
+let connections;
 
 function preload() {
   // Load the bodyPose model
@@ -22,11 +26,30 @@ function setup() {
 
   // Start detecting poses in the webcam video
   bodyPose.detectStart(video, gotPoses);
+  //get the skeleton connection information
+  connections = bodyPose.getSkeleton();
 }
 
 function draw() {
   // Draw the webcam video
   image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
 
   // Draw all the tracked landmark points
   for (let i = 0; i < poses.length; i++) {


### PR DESCRIPTION
Here are my (small) adjustments to @QuinnHe's bodypose content rewrite. Some changes:

1. Consistent use of file names (i.e., "index.html" instead of "the HTML file")
2. Structural changes - combined demo and quick start, renamed "how to" to "tutorial", and changed H4 to H3 where necessary
3. Camel case when referencing model
4. Reduce directional language
5. The rest is mostly corrections to grammatical errors, eliminating redundancy when excessive, and minor adjustments to language just so things flow better

Other questions:

1. Is it possible to change the color of bold text? It's very similar to the color of links which can be misleading.
2. I wonder if we can shorten the code in the tutorial so that it doesn't feel too lengthy? Maybe only include the snippet that's being added after each explanation so it's more clear where the change is happening, and then including the full code altogether at the end (or beginning)? As opposed to the current version that is copying the entire code from the previous instructions and adding to it each time. 

Anything you are not happy with let me know, and I can change it back! I know there's also some discussion around fixing the Methods section so feel free to add to that.