### PR TITLE
Added lightbulb tip style

### DIFF
--- a/docs/css/style-markdown.css
+++ b/docs/css/style-markdown.css
@@ -546,9 +546,21 @@ body.close .sidebar-toggle {
 .markdown-section p.warn {
   /* check this color, if we use */
   background: rgba(66, 185, 131, 0.1);
-  border-radius: 2px;
-  padding: 1rem;
+  border: 2px solid #42b983;
+  border-radius: 10px;
+  padding: 1rem 1rem 1rem 3.5rem; /* Added left padding to make space for the icon */
+  position: relative;
 }
+
+.markdown-section p.warn::before {
+  content: "💡";
+  position: absolute;
+  left: 1rem; /* Position the icon inside the padding area */
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.8rem; /* Adjust the size of the icon as needed */
+}
+
 
 .markdown-section ul.task-list>li {
   list-style-type: none;

--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -21,7 +21,7 @@ It offers flexibility for:
 
 This bodyPose example uses the MoveNet model (default model if not specified by user) to detect body poses in real-time from the webcam video. The detected keypoints are then visualized on the canvas.
 
-You can also [open the demo in the p5.js web editor](https://editor.p5js.org/ml5/sketches/vpSI23x0A), and then press the run button to see the code in action!
+?>  You can also [open the demo in the p5.js web editor](https://editor.p5js.org/ml5/sketches/vpSI23x0A), and then press the run button to see the code in action!
 
 To understand the code in detail, take a look at the following tutorial.
 


### PR DESCRIPTION
@MOQN @QuinnHe @myrahsa Hi team. While I am going through the reference of docsify for footer, I found that the usage of `?>` and `!>` in markdown will render as warn and tip style. I think this is a good solution for #77. So I made some changes to the current style to make it work as a highlighted tip for indicating open demo in p5 web editor. The result:
![CleanShot 2024-06-15 at 14 06 44@2x](https://github.com/ml5js/ml5-website-v02-docsify/assets/10086000/5eabdfc6-e61f-47fe-81ab-74977b04bc64)
