### PR TITLE
Changed `flipHorizontal` to `flipped`

### DIFF
--- a/docs/reference/body-segmentation.md
+++ b/docs/reference/body-segmentation.md
@@ -238,7 +238,7 @@ const bodySegmentation = ml5.bodySegmentation(?modelName, ?options, ?callback);
   - _SelfieSegmentation_(default): A model that can be used to segment people from the background.
   - _BodyPix_: A model that can be used to segment people and body parts.
 
-  
+
 
 - **options**: Optional. An object to change the default configuration of the model. See the example options object:
 
@@ -246,15 +246,18 @@ const bodySegmentation = ml5.bodySegmentation(?modelName, ?options, ?callback);
   {
     runtime: "tfjs", // "tfjs" or "mediapipe"
     modelType: "general", // "general" or "landscape"
-    maskType: "background" // "background", "body", or "parts" (used to change the type of segmentation mask output)
+    maskType: "background", // "background", "body", or "parts" (used to change the type of segmentation mask output)
+    flipped: false,
   }
   ```
 
   Important Option:
-  - **maskType**: The type of mask to output. The options are:
+  - _maskType_: The type of mask to output. The options are:
     - _background_: A mask of the background. The result is an image with transparent pixels on the background and black pixels on the person.
     - _body_: A mask of the person. The result is an image with black pixels on the background and transparent pixels on the person.
     - _parts_: **BodyPix** only. A mask of the body parts. The result is an image with white pixels on the background and various color pixels for each body part.
+  - _flipped_ - Optional
+    - Boolean: Flip the result horizontally. Defaults to false.
 
   [More info on options for SelfieSegmentation model with tfjs runtime](https://github.com/tensorflow/tfjs-models/tree/master/body-segmentation/src/selfie_segmentation_tfjs#create-a-detector).
 
@@ -264,7 +267,7 @@ const bodySegmentation = ml5.bodySegmentation(?modelName, ?options, ?callback);
 
 - **callback(bodySegmentation, error)**: Optional. A function to run once the model has been loaded. Alternatively, call `ml5.bodySegmentation()` within the p5 `preload` function.
 
-**Returns:**  
+**Returns:**
 
 - **Object**: The bodySegmentation object. This object contains the methods to start and stop the body segment detection process.
 
@@ -328,6 +331,5 @@ bodySegmentation.detect(media, ?callback);
 
 - **callback(output, error)**: Optional. A callback function to handle the output of the estimation, see output example above.
 
-**Returns:**  
+**Returns:**
 A promise that resolves to the segmentation output.
-

--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -342,6 +342,7 @@ let bodypose = ml5.bodypose(?model, ?options, ?callback);
     trackerType: "boundingBox", // "keypoint" or "boundingBox"
     trackerConfig: {},
     modelUrl: undefined,
+    flippped: false
   }
   ```
 
@@ -351,6 +352,8 @@ let bodypose = ml5.bodypose(?model, ?options, ?callback);
     - String: The type of model to use. Default: "MULTIPOSE_LIGHTNING".
   - _enableSmoothing_ - Optional
     - Boolean: Whether to smooth the pose landmarks across different input images to reduce jitter. Default: true.
+  - _flipped_ - Optional
+    - Boolean: Flip the result horizontally. Defaults to false.
 
   Options for the MoveNet model only:
 

--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -342,7 +342,7 @@ let bodypose = ml5.bodypose(?model, ?options, ?callback);
     trackerType: "boundingBox", // "keypoint" or "boundingBox"
     trackerConfig: {},
     modelUrl: undefined,
-    flippped: false
+    flipped: false
   }
   ```
 

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -60,7 +60,7 @@ let faceMesh;
 Next, we can create a `options` object to customize the model's behavior. For example, we can set the maximum number of faces to detect to 1, disable the refinement of landmarks (further refine the landmark coordinates around the eyes and lips at the cost of compute), and prevent the model from flipping the image horizontally.
 
 ```javascript
-let options = { maxFaces: 1, refineLandmarks: false, flipHorizontal: false };
+let options = { maxFaces: 1, refineLandmarks: false, flipped: false };
 ```
 
 ?> If you would like to know more about the available configuration settings for `options`, please check out the [Methods](/reference/facemesh?id=methods) section.
@@ -272,7 +272,7 @@ const faceMesh = ml5.faceMesh(?options, ?callback);
   {
       maxFaces: 1,
       refineLandmarks: false,
-      flipHorizontal: false
+      flipped: false
   }
   ```
 
@@ -282,7 +282,7 @@ const faceMesh = ml5.faceMesh(?options, ?callback);
     - Number: The maximum number of faces to detect. Defaults to 2.
   - _refineLandmarks_
     - Boolean: Refine the landmarks. Defaults to false.
-  - _flipHorizontal_
+  - _flipped_
     - Boolean: Flip the result horizontally. Defaults to false.
   - _runtime_
     - String: The runtime to use. "tfjs" (default) or "mediapipe".

--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -262,7 +262,7 @@ const handpose = ml5.handpose(?options, ?callback);
   ```javascript
   {
     maxHands: 2,
-    flipHorizontal: false,
+    flipped: false,
     runtime: "tfjs",
     modelType: "full",
     detectorModelUrl: undefined, //default to use the tf.hub model
@@ -276,7 +276,7 @@ const handpose = ml5.handpose(?options, ?callback);
     - Number: The maximum number of hands to detect. Default: 2.
   - _modelType_ - Optional
     - String: The type of model to use: "lite" or "full". Default: "full".
-  - _flipHorizontal_ - Optional
+  - _flipped_ - Optional
     - Boolean: Flip the result data horizontally. Default: false.
   - _runtime_ - Optional
     - String: The runtime of the model: "mediapipe" or "tfjs". Default: "tfjs".

--- a/docs/reference/iframes/facemesh/script.js
+++ b/docs/reference/iframes/facemesh/script.js
@@ -6,7 +6,7 @@
 let faceMesh;
 let video;
 let faces = [];
-let options = { maxFaces: 1, refineLandmarks: false, flipHorizontal: false };
+let options = { maxFaces: 1, refineLandmarks: false, flipped: false };
 
 function preload() {
   // Load the faceMesh model


### PR DESCRIPTION
@MOQN @QuinnHe Fixed the options: Changed `flipHorizontal` to `flipped` to match p5.

@ziyuan-linn I noticed that `flipped` is also in `BodySegmentation` and `BodyPose`, but didn't mention it in the comments and examples. Is it a valid option so we can include it in the docs?