### PR TITLE
Update iframe libraries

### DIFF
--- a/docs/reference/iframes/body-segmentation/run.html
+++ b/docs/reference/iframes/body-segmentation/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
 
   <!-- iframe CSS & JS -->

--- a/docs/reference/iframes/facemesh/run.html
+++ b/docs/reference/iframes/facemesh/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/handpose/run.html
+++ b/docs/reference/iframes/handpose/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/image-classifier-tm/run.html
+++ b/docs/reference/iframes/image-classifier-tm/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/image-classifier/run.html
+++ b/docs/reference/iframes/image-classifier/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/neural-network/run.html
+++ b/docs/reference/iframes/neural-network/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/sentiment/run.html
+++ b/docs/reference/iframes/sentiment/run.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- iframe Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/iframes/sentiment/script.js
+++ b/docs/reference/iframes/sentiment/script.js
@@ -4,44 +4,42 @@
 // https://opensource.org/licenses/MIT
 
 let sentiment;
-let statusEl; // to display model loading status
 let submitBtn;
 let inputBox;
 let sentimentResult;
 
+function preload() {
+  // Initialize the sentiment analysis model
+  sentiment = ml5.sentiment("MovieReviews");
+}
+
 function setup() {
   noCanvas();
-  // initialize sentiment analysis model
-  sentiment = ml5.sentiment("movieReviews", modelReady);
 
-  // setup the html dom elements
-  statusEl = createP("Loading Model...");
+  // Setup the DOM elements
   inputBox = createInput("Today is the happiest day and is full of rainbows!");
   inputBox.attribute("size", "75");
   submitBtn = createButton("submit");
-  sentimentResult = createP("Sentiment score:");
+  sentimentResult = createP("Sentiment confidence:");
 
-  // predicting the sentiment when submit button is pressed
+  // Start predicting when the submit button is pressed
   submitBtn.mousePressed(getSentiment);
 }
 
 function getSentiment() {
-  // get the values from the input
+  // Use the value of the input box
   let text = inputBox.value();
 
-  // make the prediction
-  let prediction = sentiment.predict(text);
-
-  // display sentiment result on html page
-  sentimentResult.html("Sentiment score: " + prediction.score);
+  // Start making the prediction
+  sentiment.predict(text, gotResult);
 }
 
-// a callback function that is called when model is ready
-function modelReady() {
-  statusEl.html("Model loaded");
+function gotResult(prediction) {
+  // Display sentiment result via the DOM
+  sentimentResult.html("Sentiment confidence: " + prediction.confidence);
 }
 
-// predicting the sentiment when 'Enter' key is pressed
+// Start predicting when the Enter key is pressed
 function keyPressed() {
   if (keyCode == ENTER) {
     getSentiment();

--- a/docs/reference/iframes/sound-classifier/run.html
+++ b/docs/reference/iframes/sound-classifier/run.html
@@ -7,7 +7,7 @@
 
     <!-- iframe Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.20.0-alpha.4/dist/ml5.min.js"></script>
+    <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
     <!-- iframe CSS & JS -->
     <link rel="stylesheet" type="text/css" href="../../../css/global.css" />


### PR DESCRIPTION
It looks like the ml5 version was already addressed in #118 but got changed back at some point (perhaps by accident?). I changed ml5 version from alpha to `ml5@1` and p5 version from `1.9.2` to `1.9.4`. All of the demos should be working properly now @QuinnHe! 

I did not change it for bodypose because the linked example is still using alpha, so the demo stops working once I switch the version. I can go back and change this after the example code gets fixed.