### PR TITLE
Fix image path for facemesh UV coordinates reference

### DIFF
--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -307,4 +307,4 @@ uvCoords = faceMesh.getUVCoords();
 ```
 
 Please refer to this image to understand the coordinates:
-![facemesh UV coordinates reference](assets/facemesh-map.jpg)
+![facemesh UV coordinates reference](https://docs.ml5js.org/assets/facemesh-map.jpg)

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -307,4 +307,4 @@ uvCoords = faceMesh.getUVCoords();
 ```
 
 Please refer to this image to understand the coordinates:
-![facemesh UV coordinates reference](/assets/facemesh-map.jpg)
+![facemesh UV coordinates reference](assets/facemesh-map.jpg)

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -307,4 +307,4 @@ uvCoords = faceMesh.getUVCoords();
 ```
 
 Please refer to this image to understand the coordinates:
-![facemesh UV coordinates reference](/docs//assets/facemesh-map.jpg)
+![facemesh UV coordinates reference](/assets/facemesh-map.jpg)


### PR DESCRIPTION
### What does this PR do?
This PR fixes a broken image link in the facemesh reference documentation.
The issue was caused by an extra `/docs//` segment in the image `src` path.

### What was changed?
- Removed the redundant `/docs//` from the image source
- Restored proper rendering of the UV coordinates image

### Related Issue
Closes #216
