### PR TITLE
References: refine language around model capabilities

### DIFF
--- a/docs/reference/body-segmentation.md
+++ b/docs/reference/body-segmentation.md
@@ -12,8 +12,8 @@ The ml5.js BodySegmentation provides two models, `SelfieSegmentation` and `BodyP
 The ml5.js BodySegmentation is built on top of the [TensorFlow.js BodyPix model and the MediaPipe Selfie Segmentation model](https://github.com/tensorflow/tfjs-models/tree/master/body-segmentation).
 
 It provides following functionalities:
-- **Real-time person/background segmentation**: The `SelfieSegmentation` model can segment people from the background in real-time, and is designed to be lightweight. The `BodyPix` model can also be used for this purpose, but is more computationally intensive.
-- **Real-time body part segmentation**: The `BodyPix` model can segment 24 body parts in real-time.
+- **Real-time person/background segmentation**: The `SelfieSegmentation` model tries to segment people from the background in real-time, and is designed to be lightweight. The `BodyPix` model can also be used for this purpose, but is more computationally intensive.
+- **Real-time body part segmentation**: The `BodyPix` model tries to segment 24 body parts in real-time.
 
 ## Quick Start
 

--- a/docs/reference/bodypose.md
+++ b/docs/reference/bodypose.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-The ml5.js BodyPose is a pretrained full-body pose estimation model that can estimate poses and track key body parts in real-time. It is developed leveraging TensorFlow's [MoveNet](https://www.tensorflow.org/hub/tutorials/movenet#:~:text=MoveNet%20is%20an%20ultra%20fast,known%20as%20Lightning%20and%20Thunder) and [BlazePose](https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker) models.
+The ml5.js BodyPose is a pretrained full-body pose estimation model that tries to estimate poses and track key body parts in real-time. It is developed leveraging TensorFlow's [MoveNet](https://www.tensorflow.org/hub/tutorials/movenet#:~:text=MoveNet%20is%20an%20ultra%20fast,known%20as%20Lightning%20and%20Thunder) and [BlazePose](https://ai.google.dev/edge/mediapipe/solutions/vision/pose_landmarker) models.
 
 It offers flexibility for:
 

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-FaceMesh is a machine-learning model that allows for facial landmark detection in the browser. It can detect multiple faces at once and provides 468 3D facial landmarks that describe the geometry of each face. FaceMesh works best when the faces in view take up a large percentage of the image or video frame and it may struggle with small/distant faces.
+FaceMesh is a machine-learning model that allows for facial landmark detection in the browser. It tries to detect multiple faces at once and provides 468 3D facial landmarks that describe the geometry of each face. FaceMesh works best when the faces in view take up a large percentage of the image or video frame and it may struggle with small/distant faces.
 
 The ml5.js FaceMesh model is ported from the [TensorFlow.js FaceMesh implementation](https://github.com/tensorflow/tfjs-models/tree/master/face-landmarks-detection).
 

--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -7,15 +7,15 @@
 
 ## Description
 
-HandPose is a machine-learning model that allows for palm detection and hand-skeleton finger tracking in the browser. It can detect multiple hands at a time and for each hand, and provides 21 2D and 3D hand keypoints that describe important locations on the palm and fingers.
+HandPose is a machine-learning model that allows for palm detection and hand-skeleton finger tracking in the browser. It tries to detect multiple hands at a time and for each hand, and provides 21 2D and 3D hand keypoints that describe important locations on the palm and fingers.
 
 The ml5.js HandPose model is based on the [HandPose implementation](https://github.com/google/mediapipe/blob/master/docs/solutions/hands.md) by TensorFlow.js.
 
 The following functionality is provided:
 
-- **Hand Keypoint Detection**: HandPose can detect the 2D and 3D coordinates of 21 keypoints on a hand.
-- **Handedness**: HandPose can determine the handedness (left or right) of the detected hand.
-- **Multiple Hands**: HandPose can detect multiple hands at the same time.
+- **Hand Keypoint Detection**: HandPose tries to detect the 2D and 3D coordinates of 21 keypoints on a hand.
+- **Handedness**: HandPose tries to determine the handedness (left or right) of the detected hand.
+- **Multiple Hands**: HandPose tries to detect multiple hands at the same time.
 
 ## Quick Start
 

--- a/docs/reference/image-classifier-tm.md
+++ b/docs/reference/image-classifier-tm.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-The ml5.js Image + Teachable Machine model allows you to create a model that can recognize the content of an image from a set of labels that you define. For example, you can train a model to tell the difference between a cat and a dog, happy and sad faces, or even between a hot dog and a sandwich.
+The ml5.js Image + Teachable Machine model allows you to create a model that tries to recognize the content of an image from a set of labels that you define. For example, you can train a model to tell the difference between a cat and a dog, happy and sad faces, or even between a hot dog and a sandwich.
 
 The ml5.js Image + Teachable Machine model is a combination of [the ml5.js imageClassifier](/reference/image-classifier) and the Teachable Machine platform. Instead of using pre-trained models like MobileNet or Darknet, you can train your own model with the [Teachable Machine](https://teachablemachine.withgoogle.com/).
 
@@ -16,7 +16,7 @@ The ml5.js Image + Teachable Machine model is a combination of [the ml5.js image
 It provides the following functionalities:
 
 - **Custom Labels**: Train your model with customized labels to recognize specific objects, animals, or people.
-- **Image Classification**: The Image + Teachable Machine model can recognize the content of an image from a set of labels that you define.
+- **Image Classification**: The Image + Teachable Machine model tries to recognize the content of an image from a set of labels that you define.
 - **Video Object Detection**: The Image + Teachable Machine model can also be used to classify objects into categories that you define in real-time video.
 
 ## Quick Start

--- a/docs/reference/image-classifier.md
+++ b/docs/reference/image-classifier.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-The ml5.js imageClassifier is a pre-trained model that tries to recognize the content of an image. It can guess the identities of objects, animals, and even people in a picture. The image classifier uses a neural network to analyze the image and provide a list of possible labels for the content of the image in its entirety.
+The ml5.js imageClassifier is a pre-trained model that tries to recognize the content of an image. It tries to guess the identities of objects, animals, and even people in a picture. The image classifier uses a neural network to analyze the image and provide a list of possible labels for the content of the image in its entirety.
 
 The ml5.js imageClassifier uses the pre-trained MobileNet model by default. You can optionally load and use other models such as Darknet as well as a custom-trained model, DoodleNet, which is also built upon the MobileNet architecture and trained on images from the Google _Quick, Draw!_ dataset.
 

--- a/docs/reference/object-detection.md
+++ b/docs/reference/object-detection.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The ml5.js objectDetection is a pre-trained model that can detect object from an image or a video, including live video source such as webcam.
+The ml5.js objectDetection is a pre-trained model that tries to detect objects from an image or a video, including live video source such as webcam.
 
 The ml5.js objectDetection uses pre-trained [Tensorflow.js CocoSsd model](https://github.com/tensorflow/tfjs-models/tree/master/coco-ssd).
 

--- a/docs/reference/sentiment.md
+++ b/docs/reference/sentiment.md
@@ -7,13 +7,13 @@
 
 ## Description
 
-Sentiment is a model trained to predict the sentiment of any given text. For example, it can predict how positive or negative a review is with a value between 0 ("negative") and 1 ("positive").
+Sentiment is a model trained to predict the sentiment of any given text. For example, it tries to predict how positive or negative a review is with a value between 0 ("negative") and 1 ("positive").
 
 The model is trained using IMDB reviews that have been truncated to a maximum of 200 words, and only the 20000 most used words in the reviews are used.
 
 It provides the following functionalities:
 
-- **Sentiment Analysis**: The model can predict the sentiment of a given text.
+- **Sentiment Analysis**: The model tries to predict the sentiment of a given text.
 
 ## Quick Start
 

--- a/docs/reference/sound-classifier.md
+++ b/docs/reference/sound-classifier.md
@@ -14,7 +14,7 @@ It provides the following functionalities:
 - **Sound identification**: Detect whether a certain noise (e.g., clapping) was made or a certain word (e.g., up, down) was said.
 - **Custom models**: Flexibility to use [TensorFlow's SpeechCommands18w](https://github.com/tensorflow/tfjs-models/tree/master/speech-commands) model or your own custom pre-trained speech commands.
 
-The SpeechCommands18w model can recognize 18 sounds which include the ten digits from "zero" to "nine", "up", "down", "left", "right", "stop", "go", "yes", and "no". It also includes the categories "background noise" and "unknown".
+The SpeechCommands18w model tries to recognize 18 sounds which include the ten digits from "zero" to "nine", "up", "down", "left", "right", "stop", "go", "yes", and "no". It also includes the categories "background noise" and "unknown".
 
 If opting to train your own model, try [Google's Teachable Machine](https://teachablemachine.withgoogle.com).
 


### PR DESCRIPTION
This adjustment was highly inspired by @enderversing's PR and @shiffman's suggestion!

Rather than saying what models "can" do, this update uses softer language like "tries to," "attempts to predict," and "tries to guess."

This better reflects the probabilistic nature of ML models: "They are not always accurate!" and the revised wording helps set more realistic expectations about accuracy, limitations, and uncertainty.
