### PR TITLE
Fix #233: Update the ml5js version used for objectDetection

### DIFF
--- a/docs/reference/iframes/object-detection/index.html
+++ b/docs/reference/iframes/object-detection/index.html
@@ -16,7 +16,7 @@
   <script>
     // Navbar will be added on the top of the page.
     // You can provide a link to the script file on the p5 web editor.
-      navbar("https://editor.p5js.org/codingeffects2023/sketches/pyC9DA8pV");
+      navbar("https://editor.p5js.org/ml5/sketches/onwqDXmAX9");
   </script>
 
   <iframe src="ready.html" name="script-iframe"></iframe>

--- a/docs/reference/iframes/object-detection/run.html
+++ b/docs/reference/iframes/object-detection/run.html
@@ -8,7 +8,7 @@
 
   <!-- iframe Libraries -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
-  <script src="https://assets.editor.p5js.org/657d0967f26417001a37b083/c50633f1-ec0e-49e2-8e5e-06d7ce0d9079.js?v=1759896253090"></script>
+  <script src="https://unpkg.com/ml5@1/dist/ml5.min.js"></script>
 
   <!-- iframe CSS & JS -->
   <link rel="stylesheet" type="text/css" href="../../../css/global.css">

--- a/docs/reference/object-detection.md
+++ b/docs/reference/object-detection.md
@@ -13,7 +13,7 @@ Run and explore a pre-built example! [This webcam example](https://editor.p5js.o
 
 <br/>
 
-[DEMO](iframes/object-detection ":include :type=iframe width=100% height=550px")
+[DEMO](iframes/object-detection/index.html ":include :type=iframe width=100% height=550px")
 
 ## Examples
 


### PR DESCRIPTION
Fixes #233 by updating the ml5js version used in demo for objectDetection to latest(1.3.1) in **object-detection/run.html**, also update the link to open in p5 web editor.