### PR TITLE
apply quick fix: resolve broken mobile view and responsive layout for…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ async function setup() {
 }
 ```
 
-## Detect hand keypoints with the model
+## Detect hand keypoints with the model {docsify-ignore}
 
 Now that the model is loaded, we can tell it to start detecting hands! We'll use the `detectStart()` function, which takes **two parameters**: the **webcam video** as our **input**, and a callback function called `gotHands` to handle the model's **output** (the detection results, **hands**).
 
@@ -164,7 +164,7 @@ function gotHands(results) {
 }
 ```
 
-## Display the results on the canvas
+## Display the results on the canvas {docsify-ignore}
 When a hand is detected, the `hands` array receives detailed data from the model. This includes the coordinates for 21 different finger joints and fingertips!
 
 Take a look at the diagram below, showing all 21 points with their names!

--- a/docs/css/style-markdown.css
+++ b/docs/css/style-markdown.css
@@ -956,8 +956,8 @@ span.emoji {
 /* mobile view adjustments for bubbles */
 @media screen and (max-width: 768px) {
 	.token.comment.bubble-comment {
-		width: 100%;
-		margin-left: 0;
+		width: 80%;
+		margin-left: auto;
 		margin-top: 0.5rem;
 		margin-bottom: 0.5rem;
 	}
@@ -1377,6 +1377,11 @@ section.cover blockquote>p>a:hover {
 	#demo,
 	.demo-iframe {
 		display: none !important;
+	}
+
+	.markdown-section {
+		width: 90%;
+		margin: 0 auto;
 	}
 }
 

--- a/docs/css/style-markdown.css
+++ b/docs/css/style-markdown.css
@@ -12,6 +12,9 @@
 /* new way in Docsify v5 to add scroll padding at the top */
 :root {
 	--scroll-padding-top: 30px;
+	--sidebar-width: 300px;
+	--sidebar-toggle-btn-width: 60px;
+	--sidebar-toggle-btn-height: 60px;
 }
 
 html,
@@ -180,7 +183,7 @@ div#app:empty::before {
 	top: 0;
 	bottom: 0;
 	left: 0;
-	width: 300px;
+	width: var(--sidebar-width);
 	overflow-y: auto;
 	transition: transform 250ms ease;
 	z-index: 950;
@@ -386,27 +389,36 @@ div#app:empty::before {
 
 /* the icon on the left bottom */
 .sidebar-toggle {
-	background-color: rgba(var(--color-sidebar-toggle-bg-rgb), 0.8);
-	border: 0;
-	outline: none;
-	padding: 15px;
+	display: none;
+
 	position: absolute;
-	bottom: 0;
 	left: 0;
-	text-align: center;
-	transition: opacity 0.3s, transform 250ms ease, background-color 1s;
-	width: auto;
-	transform: translateX(240px);
+	bottom: 0;
+
+	width: var(--sidebar-toggle-btn-width);
+	height: var(--sidebar-toggle-btn-height);
+	padding: calc(var(--sidebar-toggle-btn-height) / 4);
+	border: 0;
+
 	z-index: 1000;
 	cursor: pointer;
+	transition: opacity 0.3s, transform 250ms ease, background-color 1s;
+
+	/* background-color: rgba(var(--color-sidebar-toggle-bg-rgb), 0.8); */
+	background-color: transparent
 }
 
 .sidebar-toggle span {
-	background-color: var(--color-secondary);
+	background-color: var(--color-primary);
 	display: block;
-	margin-bottom: 4px;
-	width: 20px;
-	height: 3px;
+	margin-bottom: calc(var(--sidebar-toggle-btn-height) / 15);
+	width: calc(var(--sidebar-toggle-btn-height) / 2);
+	height: calc(var(--sidebar-toggle-btn-height) / 15);
+}
+
+
+.sidebar-toggle .sidebar-toggle-button {
+	/*  */
 }
 
 .sidebar-toggle:hover .sidebar-toggle-button {
@@ -416,24 +428,6 @@ div#app:empty::before {
 body.sticky .sidebar,
 body.sticky .sidebar-toggle {
 	position: fixed;
-}
-
-body.close .sidebar {
-	transform: translateX(-300px);
-}
-
-body.close .content {
-	left: 0;
-	width: 100%;
-}
-
-body.close .app-nav {
-	display: none;
-}
-
-body.close .sidebar-toggle {
-	width: 300px;
-	transform: translateX(0px);
 }
 
 footer {
@@ -1349,61 +1343,30 @@ section.cover blockquote>p>a:hover {
 }
 
 @media screen and (max-width: 1060px) {
-
-	.sidebar-toggle,
 	.sidebar {
-		position: fixed;
+		transform: translateX(calc(-1 * var(--sidebar-width)));
 	}
 
-	.app-nav li ul {
-		top: 30px;
+	.sidebar.show {
+		transform: translateX(0);
 	}
 
-	main {
-		height: auto;
-		min-height: 100vh;
-		overflow-x: hidden;
+	main>.content {
+		left: 0;
+		width: 100%;
 	}
 
-	body.close .sidebar {
-		transform: translateX(300px);
-	}
-
-	body.close .sidebar-toggle {
-		transform: translateX(240px);
+	.app-nav {
+		display: none;
 	}
 
 	.sidebar-toggle {
-		transform: translateX(0px);
+		display: block;
 	}
 
-	.sidebar {
-		left: -300px;
-		transition: transform 250ms ease;
+	body:has(.sidebar.show) .sidebar-toggle {
+		transform: translateX(calc(var(--sidebar-width) - var(--sidebar-toggle-btn-width)));
 	}
-
-	.content {
-		left: 0;
-		width: 100%;
-		max-width: 100vw;
-		padding-top: 60px;
-	}
-
-	.markdown-section {
-		max-width: 80%;
-	}
-
-	/* Good suggestion! But's let's try without it for a while. (M) */
-	/* footer {
-    flex-direction: column;
-  } */
-
-	/*
-  .footer-logo {
-    display: none;
-    margin: auto;
-    width: 30%;
-  } */
 }
 
 @media screen and (max-width: 700px) {
@@ -1424,24 +1387,5 @@ section.cover blockquote>p>a:hover {
 	.app-nav,
 	#banner {
 		display: none;
-	}
-}
-
-/* this can be removed..? */
-@keyframes octocat-wave {
-
-	0%,
-	100% {
-		transform: rotate(0);
-	}
-
-	20%,
-	60% {
-		transform: rotate(-25deg);
-	}
-
-	40%,
-	80% {
-		transform: rotate(10deg);
 	}
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,8 @@
 			plugins: [
 				window.ml5DocsPlugins.prismCustomPlugin,
 				window.ml5DocsPlugins.examplesSearchPlugin,
-				window.ml5DocsPlugins.clearSearchTextPlugin
+				window.ml5DocsPlugins.clearSearchTextPlugin,
+				window.ml5DocsPlugins.sidebarStatePlugin
 			]
 		}
 	</script>

--- a/docs/js/custom-plugins.js
+++ b/docs/js/custom-plugins.js
@@ -92,10 +92,48 @@
     });
   };
 
+  const sidebarStatePlugin = function (hook) {
+    const sidebarMobileBreakpoint = 1060;
+    let hasResizeListener = false;
+    let lastIsMobile = null;
+
+    const sidebarStateByViewport = () => {
+      const sidebar = document.querySelector('.sidebar');
+      if (!sidebar) return;
+
+      const isMobile = window.innerWidth <= sidebarMobileBreakpoint;
+      if (isMobile) {
+        // mobile view starts with sidebar hidden, but the toggle button is visible!
+        sidebar.classList.remove('show');
+      } else {
+        // laptop/desktop view starts with sidebar visible; (the toggle button will be hidden.)
+        sidebar.classList.add('show');
+      }
+      lastIsMobile = isMobile;
+    };
+
+    hook.ready(function () {
+      sidebarStateByViewport();
+
+      if (!hasResizeListener) {
+        window.addEventListener('resize', function () {
+          const isMobile = window.innerWidth <= sidebarMobileBreakpoint;
+          if (lastIsMobile === null || isMobile !== lastIsMobile) {
+            sidebarStateByViewport();
+          }
+        });
+        hasResizeListener = true;
+      }
+    });
+
+    hook.doneEach(sidebarStateByViewport);
+  };
+
   window.ml5DocsPlugins = {
     prismCustomPlugin,
     examplesSearchPlugin,
-    clearSearchTextPlugin
+    clearSearchTextPlugin,
+    sidebarStatePlugin
   };
 
 })();


### PR DESCRIPTION
The mobile view was completely broken after updating to Docsify v5! I apologize for noticing this late! 

It took almost half a day, as the documentation wasn't there yet... 😭  I realized that they dropped the old logic and switched to a totally new approach (`body:has(.sidebar.show) .sidebar-toggle`). I was able to learn the new method by looking into [core.min.css](https://cdn.jsdelivr.net/npm/docsify@5/dist/themes/core.min.css) from Docsify's example. 🎉

Anyway, I believe it should be fine now :D I will be merging this soon as it's critical for the viewers.

<br><br>


Again, Copilot's generated text :D
---
This pull request enhances the documentation site's sidebar responsiveness and improves mobile usability. The main changes include a new plugin for managing sidebar state based on viewport size, significant CSS refactoring for sidebar and toggle button behavior, and minor documentation improvements.

**Sidebar Responsiveness and Behavior:**

* Added a new `sidebarStatePlugin` to `custom-plugins.js` to automatically show or hide the sidebar based on viewport width, ensuring the sidebar is hidden by default on mobile and visible on desktop. This plugin also updates the sidebar state on window resize and page navigation.
* Registered the new `sidebarStatePlugin` in the Docsify plugins array in `index.html`.

**CSS Refactoring for Sidebar and Toggle Button:**

* Introduced new CSS variables (`--sidebar-width`, `--sidebar-toggle-btn-width`, `--sidebar-toggle-btn-height`) and refactored sidebar and toggle button styles for consistency and responsiveness. Adjusted widths, transitions, and display logic for mobile and desktop layouts. [[1]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aR15-R17) [[2]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aL183-R186) [[3]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aL389-R421) [[4]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aL1352-L1406)
* Removed obsolete and redundant sidebar-related CSS for the closed state, and cleaned up unused keyframes. [[1]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aL421-L438) [[2]](diffhunk://#diff-1e63ef75255abd72f22d5e72acd94f710831be9c964788d2ea096ef72a8c3b5aL1429-L1447)

**Documentation Improvements:**

* Added `{docsify-ignore}` to certain markdown section headers in `README.md` to prevent them from appearing in the sidebar navigation. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L118-R118) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L167-R167)